### PR TITLE
feat: show mock 3D Tesla background in install guide

### DIFF
--- a/src/app/install-guides/cybershade-irx-tesla-model-y/page.tsx
+++ b/src/app/install-guides/cybershade-irx-tesla-model-y/page.tsx
@@ -13,7 +13,12 @@ import {
 } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import Image from "next/image"
-import Tesla3DSection from "@/components/products/Tesla3DSection"
+import dynamic from "next/dynamic"
+
+const Tesla3DBackground = dynamic(
+  () => import("@/components/3d/Tesla3DBackground"),
+  { ssr: false }
+)
 
 export const metadata: Metadata = {
   title: "CyberShade IRX Tesla Model Y Installation Guide - OpticWorks",
@@ -106,6 +111,7 @@ const troubleshooting = [
 export default function CyberShadeIRXInstallGuide() {
   return (
     <main className="relative">
+      <Tesla3DBackground />
       <FadeContainer className="relative px-6 pt-28 pb-16 lg:px-8">
         <div className="mx-auto max-w-4xl">
           {/* Header */}
@@ -153,9 +159,6 @@ export default function CyberShadeIRXInstallGuide() {
               </div>
             </div>
           </FadeDiv>
-
-          {/* Interactive 3D Tesla Model */}
-          <Tesla3DSection />
 
           {/* Installation Steps */}
           <FadeDiv className="mb-12">

--- a/src/app/install-guides/cybershade-irx-tesla-model-y/page.tsx
+++ b/src/app/install-guides/cybershade-irx-tesla-model-y/page.tsx
@@ -13,12 +13,7 @@ import {
 } from "@heroicons/react/24/outline"
 import Link from "next/link"
 import Image from "next/image"
-import dynamic from "next/dynamic"
-
-const Tesla3DBackground = dynamic(
-  () => import("@/components/3d/Tesla3DBackground"),
-  { ssr: false }
-)
+import Tesla3DBackground from "@/components/3d/Tesla3DBackground"
 
 export const metadata: Metadata = {
   title: "CyberShade IRX Tesla Model Y Installation Guide - OpticWorks",

--- a/src/components/3d/Tesla3DBackground.tsx
+++ b/src/components/3d/Tesla3DBackground.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import Scene from './Scene'
+import TeslaModel from './TeslaModel'
+
+export default function Tesla3DBackground() {
+  return (
+    <div className="fixed inset-0 -z-10 pointer-events-none">
+      <Scene className="w-full h-full">
+        <TeslaModel />
+      </Scene>
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(0,0,0,0)_60%,rgba(0,0,0,0.6)_100%)]" />
+    </div>
+  )
+}

--- a/src/components/products/Tesla3DSection.tsx
+++ b/src/components/products/Tesla3DSection.tsx
@@ -5,20 +5,8 @@ import { FadeDiv } from '@/components/Fade'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
-import dynamic from 'next/dynamic'
 import ThreeDErrorBoundary from '@/components/3d/ErrorBoundary'
-
-const Tesla3DViewer = dynamic(() => import('@/components/3d/Tesla3DViewer'), {
-  ssr: false,
-  loading: () => (
-    <div className="w-full h-96 bg-gray-100 rounded-lg flex items-center justify-center">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mx-auto mb-4"></div>
-        <p className="text-gray-600">Loading 3D Model...</p>
-      </div>
-    </div>
-  )
-})
+import Tesla3DViewer from '@/components/3d/Tesla3DViewer'
 
 export default function Tesla3DSection() {
   const [show3D, setShow3D] = useState(false)


### PR DESCRIPTION
## Summary
- Load mock Tesla 3D scene on install guide pages by default
- Render 3D scene behind content with subtle vignette overlay

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e404e7a0832a9c0620fc98d79c1a