### PR TITLE
Fix cart badge not updating

### DIFF
--- a/src/components/menu-bar.tsx
+++ b/src/components/menu-bar.tsx
@@ -3,7 +3,6 @@
 import * as React from "react"
 import { motion } from "framer-motion"
 import { Home, Package, Store, Headphones, BookOpen, ShoppingCart } from "lucide-react"
-import { useTheme } from "next-themes"
 import Link from "next/link"
 import { siteConfig } from "@/app/siteConfig"
 import { useCart } from "@/hooks/useCart"
@@ -77,20 +76,14 @@ interface MenuBarProps {
 }
 
 export const MenuBar = React.memo(function MenuBar({ isLandingPage = false }: MenuBarProps) {
-  const { theme } = useTheme()
-  const { getTotalItems } = useCart()
+  const totalItems = useCart(
+    (state) => state.items.reduce((total, item) => total + item.quantity, 0)
+  )
   const [mounted, setMounted] = React.useState(false)
 
   React.useEffect(() => {
     setMounted(true)
   }, [])
-
-  // Memoize expensive calculations
-  const totalItems = React.useMemo(() => {
-    return mounted ? getTotalItems() : 0
-  }, [mounted, getTotalItems])
-
-  // const isDarkTheme = theme === "dark" // Removed for now, not used in simplified version
 
   const headerClass = isLandingPage
     ? "fixed inset-x-4 top-4 z-50 mx-auto flex max-w-6xl justify-center"

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -15,7 +15,9 @@ export function NavBar() {
   const [open, setOpen] = React.useState(false)
   const [mounted, setMounted] = React.useState(false)
   const scrolled = useScroll(15)
-  const { getTotalItems } = useCart()
+  const totalItems = useCart(
+    (state) => state.items.reduce((total, item) => total + item.quantity, 0)
+  )
 
   React.useEffect(() => {
     setMounted(true)
@@ -60,9 +62,9 @@ export function NavBar() {
             >
               <Link href="/store/cart">
                 <ShoppingCartIcon className="w-5 h-5" />
-                {mounted && getTotalItems() > 0 && (
+                {mounted && totalItems > 0 && (
                   <span className="absolute -top-1 -right-1 bg-orange-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center">
-                    {getTotalItems()}
+                    {totalItems}
                   </span>
                 )}
               </Link>


### PR DESCRIPTION
## Summary
- derive cart item count from Zustand state so navigation cart badge updates
- clean up unused theme hook
- align legacy navbar with new cart count logic

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1224fb610832ab4558f0c5ef02944