### PR TITLE
Add Google Analytics tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,8 @@ import { Toaster } from "@/components/ui/sonner"
 import Footer from "@/components/ui/Footer"
 import { MenuBar } from "@/components/menu-bar"
 import { ThemeProvider } from "@/components/theme-provider"
-import { GoogleAnalytics } from "@/components/GoogleAnalytics"
 import { siteConfig } from "./siteConfig"
+import Script from "next/script"
 
 // Define Barlow font
 const barlowFont = localFont({
@@ -122,12 +122,22 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID
-
   return (
     <html lang="en" className={`${barlowFont.variable} ${colfaxFont.variable} ${featureFont.variable} ${featureCondensedFont.variable}`} suppressHydrationWarning>
       <head>
-        {gaId && <GoogleAnalytics measurementId={gaId} />}
+        <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-ZVKN68R4Y7"
+        />
+        <Script id="google-analytics">
+          {`
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-ZVKN68R4Y7');
+  `}
+        </Script>
       </head>
       <body className="min-h-screen overflow-x-hidden scroll-auto bg-gray-50 antialiased selection:bg-orange-100 selection:text-orange-600 font-colfax">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -20,6 +20,8 @@ export interface GAPurchaseEvent {
   items: GAEcommerceItem[]
 }
 
+const GA_MEASUREMENT_ID = 'G-ZVKN68R4Y7'
+
 // Helper function to track Google Analytics events
 export const trackGAEvent = ({ action, category, label, value }: GAEvent) => {
   if (typeof window !== 'undefined' && window.gtag) {
@@ -34,7 +36,7 @@ export const trackGAEvent = ({ action, category, label, value }: GAEvent) => {
 // Helper function to track page views
 export const trackPageView = (url: string) => {
   if (typeof window !== 'undefined' && window.gtag) {
-    window.gtag('config', process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID!, {
+    window.gtag('config', GA_MEASUREMENT_ID, {
       page_path: url,
     })
   }


### PR DESCRIPTION
## Summary
- embed GA4 tracking snippet in the global layout so every page initializes Google Analytics
- reference the GA4 measurement ID in analytics helpers

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ba299c81d0832aba95e11f72bfec5a