### PR TITLE
feat: track page views and contact form

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import Footer from "@/components/ui/Footer"
 import { MenuBar } from "@/components/menu-bar"
 import { ThemeProvider } from "@/components/theme-provider"
 import { siteConfig } from "./siteConfig"
-import Script from "next/script"
+import { GoogleAnalytics } from "@/components/GoogleAnalytics"
 
 // Define Barlow font
 const barlowFont = localFont({
@@ -124,22 +124,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${barlowFont.variable} ${colfaxFont.variable} ${featureFont.variable} ${featureCondensedFont.variable}`} suppressHydrationWarning>
-      <head>
-        <Script
-          async
-          src="https://www.googletagmanager.com/gtag/js?id=G-ZVKN68R4Y7"
-        />
-        <Script id="google-analytics">
-          {`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-ZVKN68R4Y7');
-  `}
-        </Script>
-      </head>
       <body className="min-h-screen overflow-x-hidden scroll-auto bg-gray-50 antialiased selection:bg-orange-100 selection:text-orange-600 font-colfax">
+        <GoogleAnalytics measurementId="G-ZVKN68R4Y7" />
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
           <MenuBar />
           {children}

--- a/src/components/support/ContactForm.tsx
+++ b/src/components/support/ContactForm.tsx
@@ -104,6 +104,13 @@ export function ContactForm() {
 
       const result = await response.json()
       console.log('Support request sent:', result)
+
+      if (typeof window !== 'undefined' && typeof window.gtag === 'function') {
+        window.gtag('event', 'contact_form_submit', {
+          support_category: data.category,
+          priority: data.priority
+        })
+      }
       
       // TODO: Handle file attachments in future enhancement
       if (uploadedFiles.length > 0) {


### PR DESCRIPTION
## Summary
- integrate GoogleAnalytics component in root layout to send pageview events on SPA navigation
- fire GA event when support contact form is submitted

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Error: Neither apiKey nor config.authenticator provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ba308adc10832ab82fbaea600e3a19