### PR TITLE
feat: add skyloom-inspired noisy gradient

### DIFF
--- a/public/images/noise.svg
+++ b/public/images/noise.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <filter id="noiseFilter">
+    <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="3" stitchTiles="stitch"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noiseFilter)" opacity="0.08"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,3 +231,13 @@
     opacity: 100;
   }
 }
+@layer utilities {
+  .bg-noisy-gradient {
+    background-image:
+      radial-gradient(115% 115% at 50% 0%, #3b0764 0%, #0f172a 60%, #000000 100%),
+      url("/images/noise.svg");
+    background-size: cover, 200px 200px;
+    background-repeat: no-repeat, repeat;
+    background-blend-mode: overlay;
+  }
+}

--- a/src/components/ui/Hero.tsx
+++ b/src/components/ui/Hero.tsx
@@ -3,7 +3,6 @@
 import { RiArrowRightUpLine } from "@remixicon/react"
 import Link from "next/link"
 import { FadeContainer, FadeDiv, FadeSpan } from "../Fade"
-import { VideoBackground } from "./VideoBackground"
 
 // Track button clicks
 function trackButtonClick(buttonName: string, href: string) {
@@ -61,11 +60,7 @@ export function Hero() {
             Shop Tint Kits
           </Link>
         </FadeDiv>
-        <div className="absolute inset-0 -z-10">
-          <VideoBackground 
-            videoUrl="https://pub-7268d532bc454f39b3de3c39e3d5105b.r2.dev/demo-video.mp4"
-          />
-        </div>
+        <div className="absolute inset-0 -z-10 bg-noisy-gradient" />
       </FadeContainer>
     </section>
   )


### PR DESCRIPTION
## Summary
- add reusable `bg-noisy-gradient` utility and grain texture
- replace hero video with noisy gradient background

## Testing
- `pnpm run lint`
- `pnpm run build` *(fails: Failed to collect page data for /api/order-details)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7e8b73fc832ab9bb1d82c265eabd