### PR TITLE
Add animated Model Y window outline to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { CallToAction } from "@/components/ui/CallToAction"
 import FeatureDivider from "@/components/ui/FeatureDivider"
 import Features from "@/components/ui/Features"
 import { Hero } from "@/components/ui/Hero"
+import { ModelYWindowOutline } from "@/components/ui/ModelYWindowOutline"
 import { Map } from "@/components/ui/Map/Map"
 import { SolarAnalytics } from "@/components/ui/SolarAnalytics"
 import Testimonial from "@/components/ui/Testimonial"
@@ -10,7 +11,10 @@ export default function Home() {
   return (
     <main className="relative mx-auto flex flex-col">
       <Hero />
-      <div className="mt-52 px-4 xl:px-0">
+      <div className="mt-32 px-4 xl:px-0">
+        <ModelYWindowOutline className="mx-auto" />
+      </div>
+      <div className="mt-32 px-4 xl:px-0">
         <Features />
       </div>
       <div className="mt-32 px-4 xl:px-0">

--- a/src/components/ui/ModelYWindowOutline.tsx
+++ b/src/components/ui/ModelYWindowOutline.tsx
@@ -1,0 +1,39 @@
+import { cx } from "@/lib/utils"
+
+interface ModelYWindowOutlineProps {
+  className?: string
+}
+
+export function ModelYWindowOutline({ className }: ModelYWindowOutlineProps) {
+  return (
+    <div className={cx("w-full max-w-md", className)}>
+      <svg
+        viewBox="0 0 400 200"
+        className="h-auto w-full"
+        fill="none"
+        strokeWidth={4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path
+          d="M30 150H370L350 120L300 100H100L70 120Z"
+          stroke="#4b5563"
+        />
+        <path
+          d="M110 110H290L320 135H90Z"
+          stroke="#0ea5e9"
+          strokeDasharray="600"
+          strokeDashoffset="600"
+        >
+          <animate
+            attributeName="stroke-dashoffset"
+            from="600"
+            to="0"
+            dur="4s"
+            repeatCount="indefinite"
+          />
+        </path>
+      </svg>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add ModelYWindowOutline component with animated window path
- showcase new SVG component on landing page beneath hero

## Testing
- `pnpm run lint`
- `STRIPE_SECRET_KEY=sk_test_123 NEXT_PUBLIC_SUPABASE_URL=http://localhost SUPABASE_SERVICE_ROLE_KEY=dummy pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba829c07f4832a9b617555821d1859